### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,33 +1,33 @@
-﻿// keywords.txt
+// keywords.txt
 
 SDS011_vers	KEYWORD1
 //begin	KEYWORD2
 
 //2----------------------
-SetDataReportingMode KEYWORD2
-SetQueryReporting KEYWORD2
-SetActiveReportingMode KEYWORD2
+SetDataReportingMode	KEYWORD2
+SetQueryReporting	KEYWORD2
+SetActiveReportingMode	KEYWORD2
 
 //4----------------------
-QueryDataCommand KEYWORD2
-read_q KEYWORD2
-read_a KEYWORD2
+QueryDataCommand	KEYWORD2
+read_q	KEYWORD2
+read_a	KEYWORD2
 
 //5---------------------
-SetDeviceID KEYWORD2
+SetDeviceID	KEYWORD2
 
 //6---------------------
-SetSleepAndWork KEYWORD2
-SetSleep KEYWORD2
-SetWork KEYWORD2
-wakeup KEYWORD2
-sleep KEYWORD2
+SetSleepAndWork	KEYWORD2
+SetSleep	KEYWORD2
+SetWork	KEYWORD2
+wakeup	KEYWORD2
+sleep	KEYWORD2
 
 //7-----------------
-CheckFirmwareVersion KEYWORD2
+CheckFirmwareVersion	KEYWORD2
 
 //8-----------------
-SetWorkingPeriod KEYWORD2
-SetContinuousMode KEYWWORD2
-SetWorkingPeriod3Min KEYWORD2
+SetWorkingPeriod	KEYWORD2
+SetContinuousMode	KEYWORD2
+SetWorkingPeriod3Min	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords